### PR TITLE
#150438337 Implement Dashboard for Authenticated Users

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -2046,4 +2046,18 @@ footer p span {
   right: -0.357em;
   display: inline-block;
   content: '.';
+.dashboard-body {
+  padding-top: 30px;
+}
+
+.dashboard-body nav>a {
+  color: red;
+}
+
+ul.nav.nav-tabs li a {
+  color: #428bca;
+}
+
+ul.nav.nav-tabs li.active a {
+  color: orange;
 }

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -1,4 +1,5 @@
-angular.module('mean', ['ngCookies', 'ngResource', 'ui.bootstrap', 'ngRoute', 'ngSanitize', 'mean.system', 'mean.directives'])
+angular.module('mean', ['ngCookies', 'ngResource', 'ui.bootstrap',
+  'ngRoute', 'ngSanitize', 'mean.system', 'mean.directives', 'mean.components'])
   .config(['$routeProvider',
     ($routeProvider) => {
       $routeProvider
@@ -19,6 +20,9 @@ angular.module('mean', ['ngCookies', 'ngResource', 'ui.bootstrap', 'ngRoute', 'n
         })
         .when('/signup', {
           templateUrl: '/views/signup.html'
+        })
+        .when('/dashboard', {
+          templateUrl: '/views/dashboard.html'
         })
         .when('/choose-avatar', {
           templateUrl: '/views/choose-avatar.html'
@@ -54,3 +58,4 @@ angular.module('mean', ['ngCookies', 'ngResource', 'ui.bootstrap', 'ngRoute', 'n
 
 angular.module('mean.system', []);
 angular.module('mean.directives', []);
+angular.module('mean.components', []);

--- a/client/js/components/donations.js
+++ b/client/js/components/donations.js
@@ -1,0 +1,29 @@
+angular.module('mean.components')
+  .component('donations', {
+    templateUrl: '/views/donations.html',
+    controller: donationsCtrl,
+    controllerAs: '$donationsCtrl'
+  });
+
+donationsCtrl.$inject = ['dashboard'];
+
+
+/**
+ * Donations controller
+ * @param {any} dashboard service that serves the components in dashboard
+* @return {void}
+ */
+function donationsCtrl(dashboard) {
+  const vm = this;
+  vm.$onInit = () => {
+    vm.donations = [];
+    vm.fetchDonations();
+  };
+  vm.fetchDonations = () => {
+    dashboard.fetchDonations()
+      .then((response) => {
+        vm.donations = response.data;
+      })
+      .catch(error => (error));
+  };
+}

--- a/client/js/components/gameLog.js
+++ b/client/js/components/gameLog.js
@@ -1,0 +1,29 @@
+angular.module('mean.components')
+  .component('gameLog', {
+    templateUrl: '/views/gameLog.html',
+    controller: gameLogController,
+    controllerAs: '$ctrl'
+  });
+
+gameLogController.$inject = ['dashboard'];
+
+/**
+ * Game log controller
+ * @param {any} dashboard service that serves the components in dashboard
+* @return {void}
+ */
+function gameLogController(dashboard) {
+  const vm = this;
+  vm.$onInit = () => {
+    vm.records = [];
+    vm.fetchRecords();
+  };
+  vm.fetchRecords = () => {
+    dashboard.fetchRecords()
+      .then((response) => {
+        vm.records = response.data;
+      })
+      .catch(error => (error));
+  };
+}
+

--- a/client/js/components/leaderboard.js
+++ b/client/js/components/leaderboard.js
@@ -1,0 +1,28 @@
+angular.module('mean.components')
+  .component('leaderBoard', {
+    templateUrl: '/views/leaderBoard.html',
+    controller: leaderBoardCtrl,
+    controllerAs: '$leaderCtrl'
+  });
+
+leaderBoardCtrl.$inject = ['dashboard'];
+
+/**
+ * Leader Board controller
+ * @param {any} dashboard service that serves the components in dashboard
+* @return {void}
+ */
+function leaderBoardCtrl(dashboard) {
+  const vm = this;
+  vm.$onInit = () => {
+    vm.leaderBoard = [];
+    vm.fetchLeaderBoard();
+  };
+  vm.fetchLeaderBoard = () => {
+    dashboard.fetchLeaderBoard()
+      .then((response) => {
+        vm.leaderBoard = response.data;
+      })
+      .catch(error => (error));
+  };
+}

--- a/client/js/controllers/index.js
+++ b/client/js/controllers/index.js
@@ -23,7 +23,6 @@ angular.module('mean.system')
       $scope.signOut = () => {
         TokenService.clearToken();
         TokenService.clearUser();
-        TokenService.clearUserId();
         $location.path('#!/');
       };
 

--- a/client/js/controllers/index.js
+++ b/client/js/controllers/index.js
@@ -49,7 +49,6 @@ angular.module('mean.system')
             .then(({ data: { token, user } }) => {
               AuthService.saveToken(token);
               TokenService.saveUser(user);  // eslint-disable-line
-              TokenService.saveUserId(user._id);  // eslint-disable-line
               $location.path('/#!');
             })
             .catch(({ data: { message } }) => {

--- a/client/js/controllers/index.js
+++ b/client/js/controllers/index.js
@@ -32,12 +32,7 @@ angular.module('mean.system')
           AuthService.login($scope.email, $scope.password)
             .then(({ data: { token, user } }) => {
               AuthService.saveToken(token);
-<<<<<<< HEAD
               TokenService.saveUser(user);  // eslint-disable-line
-=======
-              TokenService.saveUser(user);
-              TokenService.saveUserId(user._id);  // eslint-disable-line
->>>>>>> bug/fix-authenticated
               $location.path('/#!');
             })
             .catch(({ data: { message } }) => {
@@ -53,12 +48,8 @@ angular.module('mean.system')
           AuthService.signUp($scope.username, $scope.email, $scope.password)
             .then(({ data: { token, user } }) => {
               AuthService.saveToken(token);
-<<<<<<< HEAD
               TokenService.saveUser(user);  // eslint-disable-line
-=======
-              TokenService.saveUser(user);
-              TokenService.saveUserId(user._id);   // eslint-disable-line
->>>>>>> bug/fix-authenticated
+              TokenService.saveUserId(user._id);  // eslint-disable-line
               $location.path('/#!');
             })
             .catch(({ data: { message } }) => {

--- a/client/js/controllers/index.js
+++ b/client/js/controllers/index.js
@@ -32,7 +32,12 @@ angular.module('mean.system')
           AuthService.login($scope.email, $scope.password)
             .then(({ data: { token, user } }) => {
               AuthService.saveToken(token);
+<<<<<<< HEAD
               TokenService.saveUser(user);  // eslint-disable-line
+=======
+              TokenService.saveUser(user);
+              TokenService.saveUserId(user._id);  // eslint-disable-line
+>>>>>>> bug/fix-authenticated
               $location.path('/#!');
             })
             .catch(({ data: { message } }) => {
@@ -48,7 +53,12 @@ angular.module('mean.system')
           AuthService.signUp($scope.username, $scope.email, $scope.password)
             .then(({ data: { token, user } }) => {
               AuthService.saveToken(token);
+<<<<<<< HEAD
               TokenService.saveUser(user);  // eslint-disable-line
+=======
+              TokenService.saveUser(user);
+              TokenService.saveUserId(user._id);   // eslint-disable-line
+>>>>>>> bug/fix-authenticated
               $location.path('/#!');
             })
             .catch(({ data: { message } }) => {

--- a/client/js/directives.js
+++ b/client/js/directives.js
@@ -2,13 +2,13 @@ angular.module('mean.directives', [])
   .directive('player', () => ({
     restrict: 'EA',
     templateUrl: '/views/player.html',
-    link(scope, elem, attr) {
+    link(scope) {
       scope.colors = ['#7CE4E8', '#FFFFa5', '#FC575E', '#F2ADFF', '#398EC4', '#8CFF95'];
     }
   })).directive('answers', () => ({
     restrict: 'EA',
     templateUrl: '/views/answers.html',
-    link(scope, elem, attr) {
+    link(scope) {
       scope.$watch('game.state', () => {
         if (scope.game.state === 'winner has been chosen') {
           const curQ = scope.game.curQuestion;
@@ -35,7 +35,8 @@ angular.module('mean.directives', [])
               curQuestionArr.splice(3, 0, startStyle + cardText + endStyle);
             }
             curQ.text = curQuestionArr.join('');
-            // Clean up the last punctuation mark in the question if there already is one in the answer
+            // Clean up the last punctuation mark in the question if there
+            // already is one in the answer
             if (shouldRemoveQuestionPunctuation) {
               if (curQ.text.indexOf('.', curQ.text.length - 2) === curQ.text.length - 1) {
                 curQ.text = curQ.text.slice(0, curQ.text.length - 2);
@@ -49,16 +50,15 @@ angular.module('mean.directives', [])
     }
   })).directive('question', () => ({
     restrict: 'EA',
-    templateUrl: '/views/question.html',
-    link(scope, elem, attr) {}
+    templateUrl: '/views/question.html'
   }))
   .directive('timer', () => ({
     restrict: 'EA',
-    templateUrl: '/views/timer.html',
-    link(scope, elem, attr) {}
-  })).directive('landing', () => ({
+    templateUrl: '/views/timer.html'
+  }))
+  .directive('landing', () => ({
     restrict: 'EA',
-    link(scope, elem, attr) {
+    link(scope) {
       scope.showOptions = true;
 
       if (scope.$$childHead.global.authenticated === true) {

--- a/client/js/services/dashboard.js
+++ b/client/js/services/dashboard.js
@@ -1,0 +1,13 @@
+angular.module('mean.system')
+  .factory('dashboard', ['$http', $http => ({
+    fetchRecords() {
+      return $http.get('/api/games/history');
+    },
+    fetchLeaderBoard() {
+      return $http.get('/api/leaderboard');
+    },
+    fetchDonations() {
+      return $http.get('/api/donations');
+    }
+  }
+  )]);

--- a/client/js/services/game.js
+++ b/client/js/services/game.js
@@ -133,9 +133,8 @@ angular.module('mean.system')
               }
             }
           }
-          if (data.state === 'game ended'
-            && data.gameWinner === game.playerIndex) {
-            // get players
+          if (data.state === 'game ended') {
+          // get players
             const currentPlayers = [];
             for (let m = 0; m < data.players.length; m += 1) {
               currentPlayers.push(data.players[m].username);
@@ -145,7 +144,9 @@ angular.module('mean.system')
             // define the gameLog payload
             const gamePayload = {
               gameId,
-              winner: data.players[game.playerIndex].username,
+              // winner: data.players[game.playerIndex].username,
+              winner: game.players[game.gameWinner].username,
+              winnerId: game.players[game.gameWinner].userId,
               players: currentPlayers,
               rounds: game.round
             };
@@ -217,9 +218,14 @@ angular.module('mean.system')
         mode = mode || 'joinGame';
         room = room || '';
         createPrivate = createPrivate || false;
+        let userID;
         const user = LocalStorageService.getUser();
-        const userObject = JSON.parse(user);
-        const userID = userObject._id || 'unauthenticated'; //eslint-disable-line
+        if (user) {
+          const userObject = JSON.parse(user) || {};
+          userID = userObject._id; //eslint-disable-line
+        } else {
+          userID = 'unauthenticated';
+        }
         socket.emit(mode, { userID, room, createPrivate });
       };
 

--- a/client/js/services/game.js
+++ b/client/js/services/game.js
@@ -217,9 +217,13 @@ angular.module('mean.system')
         mode = mode || 'joinGame';
         room = room || '';
         createPrivate = createPrivate || false;
+<<<<<<< HEAD
         const user = LocalStorageService.getUser();
         const userObject = JSON.parse(user);
         const userID = userObject._id || 'unauthenticated'; //eslint-disable-line
+=======
+      const userID = LocalStorageService.getUserId() || 'unauthenticated'; //eslint-disable-line
+>>>>>>> bug/fix-authenticated
         socket.emit(mode, { userID, room, createPrivate });
       };
 

--- a/client/js/services/game.js
+++ b/client/js/services/game.js
@@ -217,13 +217,9 @@ angular.module('mean.system')
         mode = mode || 'joinGame';
         room = room || '';
         createPrivate = createPrivate || false;
-<<<<<<< HEAD
         const user = LocalStorageService.getUser();
         const userObject = JSON.parse(user);
         const userID = userObject._id || 'unauthenticated'; //eslint-disable-line
-=======
-      const userID = LocalStorageService.getUserId() || 'unauthenticated'; //eslint-disable-line
->>>>>>> bug/fix-authenticated
         socket.emit(mode, { userID, room, createPrivate });
       };
 

--- a/client/js/services/token.js
+++ b/client/js/services/token.js
@@ -11,7 +11,6 @@ angular
     clearToken: () => (
       $window.localStorage.removeItem('token')
     ),
-<<<<<<< HEAD
     saveUser: user => (
       $window.localStorage.setItem('user', JSON.stringify(user))
     ),
@@ -21,22 +20,5 @@ angular
     clearUser: () => {
       $window.localStorage.removeItem('user');
     }
-=======
-    saveUserId: userId => (
-      $window.localStorage.setItem('userId', userId)
-    ),
-    getUserId: () => (
-      $window.localStorage.getItem('userId')
-    ),
-    clearUserId: () => (
-      $window.localStorage.removeItem('userId')
-    ),
-    saveUser: user => (
-      $window.localStorage.setItem('user', user)
-    ),
-    clearUser: () => (
-      $window.localStorage.removeItem('user')
-    )
->>>>>>> bug/fix-authenticated
   })
   ]);

--- a/client/js/services/token.js
+++ b/client/js/services/token.js
@@ -11,6 +11,7 @@ angular
     clearToken: () => (
       $window.localStorage.removeItem('token')
     ),
+<<<<<<< HEAD
     saveUser: user => (
       $window.localStorage.setItem('user', JSON.stringify(user))
     ),
@@ -20,5 +21,22 @@ angular
     clearUser: () => {
       $window.localStorage.removeItem('user');
     }
+=======
+    saveUserId: userId => (
+      $window.localStorage.setItem('userId', userId)
+    ),
+    getUserId: () => (
+      $window.localStorage.getItem('userId')
+    ),
+    clearUserId: () => (
+      $window.localStorage.removeItem('userId')
+    ),
+    saveUser: user => (
+      $window.localStorage.setItem('user', user)
+    ),
+    clearUser: () => (
+      $window.localStorage.removeItem('user')
+    )
+>>>>>>> bug/fix-authenticated
   })
   ]);

--- a/client/views/dashboard.html
+++ b/client/views/dashboard.html
@@ -1,3 +1,57 @@
-<div>
-  <h1>Dashboard</h1>
+<div class="container" style="padding-top: 100px;">
+  <div class="row">
+    <div class="col-md-12">
+      <h3 class="text-center"> Dashboard </h3>
+      <!-- Header: Start -->
+      <nav class="navbar navbar-default navbar-fixed-top primary-color">
+        <div class="container">
+          <!-- Brand and toggle get grouped for better mobile display -->
+          <div class="navbar-header">
+            <button type="button" data-target="#navbarCollapse" data-toggle="collapse" class="navbar-toggle">
+                  <span class="sr-only">Toggle navigation</span>
+                  <span class="icon-bar"></span>
+                  <span class="icon-bar"></span>
+                  <span class="icon-bar"></span>
+                </button>
+            <a class="navbar-brand" id="logo" href="#"><img src="/img/logo.png" alt="logo" ></a>
+          </div>
+
+          <!-- Collection of nav links and other content for toggling -->
+          <div id="navbarCollapse" class="collapse navbar-collapse">
+            <ul class="nav navbar-nav navbar-right">
+              <li><a href="/">Home</a></li>
+            </ul>
+          </div>
+
+        </div>
+      </nav>
+      <!-- Header: End -->
+
+      <div class="dashboard-body">
+        <!-- Nav tabs -->
+        <ul class="nav nav-tabs">
+          <li role="presentation" class="active"><a  data-target="#games" role="tab" data-toggle="tab">Games</a></li>
+          <li role="presentation"><a data-target="#leaderboard" role="tab" data-toggle="tab">Leader Board</a></li>
+          <li role="presentation"><a data-target="#donation" role="tab" data-toggle="tab">Donations</a></li>
+          <li role="presentation"><a data-target="#notifications" role="tab" data-toggle="tab">Notifications</a></li>
+        </ul>
+
+        <!-- Tab panes -->
+        <div class="tab-content">
+          <div role="tabpanel" class="tab-pane active" id="games">
+            <game-log></game-log>
+          </div>
+          <div role="tabpanel" class="tab-pane" id="leaderboard">
+            <leader-board test="test"></leader-board>
+          </div>
+          <div role="tabpanel" class="tab-pane" id="donation">
+            <donations></donations>
+          </div>
+          <div role="tabpanel" class="tab-pane" id="notifications">
+            <notifications></notifications>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>  
 </div>

--- a/client/views/donations.html
+++ b/client/views/donations.html
@@ -1,0 +1,16 @@
+<table class="table table-striped table-hover">
+  <thead>
+    <tr>
+      <td><b>S/N</b></td>
+      <td><b>Amount</b></td>
+      <td><b>Date</b></td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr ng-repeat="donation in $donationsCtrl.donations">
+      <td>{{$index + 1}}</td>
+      <td>{{donation.amount}}</td>
+      <td>{{donation.date}}</td>
+    </tr>
+  </tbody>
+</table>

--- a/client/views/gameLog.html
+++ b/client/views/gameLog.html
@@ -1,0 +1,22 @@
+<table class="table table-striped table-hover">
+  <thead>
+    <tr>
+      <td><b>S/N</b></td>
+      <td><b>Winner</b></td>
+      <td><b>Rounds</b></td>
+      <td><b>Players</b></td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr ng-repeat="record in $ctrl.records">
+      <td>{{$index + 1}}</td>
+      <td>{{record.winner}}</td>
+      <td>{{record.round}}</td>
+      <td>
+        <span ng-repeat="player in record.players">
+          {{player}},
+        </span>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/client/views/index.html
+++ b/client/views/index.html
@@ -47,6 +47,7 @@
                 <li><a href="#about" onClick="scroll(0,2940);">About Us</a></li>
                 <li ng-show="showOptions()"><a href="#!/signup">Sign Up</a></li>
                 <li ng-show="showOptions()"><a href="#!/signin">Sign In</a></li>
+                <li ng-hide="showOptions()"><a href="#!/dashboard">Dashboard</a></li>
                 <li ng-hide="showOptions()"><a href="#" ng-click="signOut()">Sign Out</a></li>
               </ul>
             </div>

--- a/client/views/leaderBoard.html
+++ b/client/views/leaderBoard.html
@@ -1,0 +1,16 @@
+<table class="table table-striped table-hover">
+  <thead>
+    <tr>
+      <td><b>S/N</b></td>
+      <td><b>Winner</b></td>
+      <td><b>Number of Wins</b></td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr ng-repeat="record in $leaderCtrl.leaderBoard">
+      <td>{{$index + 1}}</td>
+      <td>{{record.name}}</td>
+      <td>{{record.gamesWon}}</td>
+    </tr>
+  </tbody>
+</table>

--- a/client/views/notifications.html
+++ b/client/views/notifications.html
@@ -1,0 +1,1 @@
+<h5>Hello from Angular component</h5>

--- a/src/app/controllers/gameLog.js
+++ b/src/app/controllers/gameLog.js
@@ -2,7 +2,6 @@ import mongoose from 'mongoose';
 /**
  * Module dependencies
  */
-import jwt from 'jsonwebtoken';
 import GameLog from './../models/gameLog';
 import User from './../models/user';
 /**
@@ -12,31 +11,29 @@ import User from './../models/user';
  * @param {any} req
  * @param {any} res
  */
-export const startGame = (req, res) => { // eslint-disable-line
-  if (req.headers.token) {
-    const playerId = jwt.decode(req.headers.token).data._id; // eslint-disable-line
-    const games = new GameLog();
-    games.playerId = playerId;
-    games.gameId = req.params.gameId;
-    games.players = req.body.players;
-    games.winner = req.body.winner;
-    games.round = req.body.rounds;
-    games.save((error) => {
-      if (error) {
-        return res.status(400).json({ message: 'Error' });
-      }
-      User.findOneAndUpdate(
-        { _id: req.body.winnerId },
-        { $inc: { gamesWon: 1 } }
-      ).then(() => (
-        res.status(200).send({ message: 'Game saved' })
-      ));
-    });
-  }
+export const startGame = (req, res) => {
+  const playerId = req.decoded.data._id; // eslint-disable-line
+  const games = new GameLog();
+  games.playerId = playerId;
+  games.gameId = req.params.gameId;
+  games.players = req.body.players;
+  games.winner = req.body.winner;
+  games.round = req.body.rounds;
+  games.save((error) => {
+    if (error) {
+      return res.status(400).json({ message: 'Error' });
+    }
+    User.findOneAndUpdate(
+      { _id: req.body.winnerId },
+      { $inc: { gamesWon: 1 } }
+    ).then(() => (
+      res.status(200).send({ message: 'Game saved' })
+    ));
+  });
 };
 
 export const retrieveGameLog = (req, res) => {
-  const playerId = jwt.decode(req.headers.token).data._id; // eslint-disable-line
+  const playerId = req.decoded.data._id; // eslint-disable-line
   GameLog.find({ playerId: mongoose.Types.ObjectId(playerId) }).select('-_id').exec((err, gameLogs) => {
     if (err) {
       res.render('error', {
@@ -64,7 +61,7 @@ export const retrieveLeaderBoard = (req, res) => {
 };
 
 export const retrieveDonations = (req, res) => {
-  const playerId = jwt.decode(req.headers.token).data._id; // eslint-disable-line
+  const playerId = req.decoded.data._id; // eslint-disable-line
   User.find({ _id: mongoose.Types.ObjectId(playerId) }).select('-_id').exec((err, user) => {
     if (err) {
       res.render('error', {

--- a/src/app/controllers/gameLog.js
+++ b/src/app/controllers/gameLog.js
@@ -1,7 +1,10 @@
+import mongoose from 'mongoose';
 /**
  * Module dependencies
  */
+import jwt from 'jsonwebtoken';
 import GameLog from './../models/gameLog';
+import User from './../models/user';
 /**
  *
  * @return {void}
@@ -10,15 +13,65 @@ import GameLog from './../models/gameLog';
  * @param {any} res
  */
 export const startGame = (req, res) => { // eslint-disable-line
-  const games = new GameLog();
-  games.id = req.params.body;
-  games.gameId = req.body.gameId;
-  games.players = req.body.players;
-  games.winner = req.body.winner;
-  games.save((error) => {
-    if (error) {
-      return res.status(400).json({ message: 'Error' });
+  if (req.headers.token) {
+    const playerId = jwt.decode(req.headers.token).data._id; // eslint-disable-line
+    const games = new GameLog();
+    games.playerId = playerId;
+    games.gameId = req.params.gameId;
+    games.players = req.body.players;
+    games.winner = req.body.winner;
+    games.round = req.body.rounds;
+    games.save((error) => {
+      if (error) {
+        return res.status(400).json({ message: 'Error' });
+      }
+      User.findOneAndUpdate(
+        { _id: req.body.winnerId },
+        { $inc: { gamesWon: 1 } }
+      ).then(() => (
+        res.status(200).send({ message: 'Game saved' })
+      ));
+    });
+  }
+};
+
+export const retrieveGameLog = (req, res) => {
+  const playerId = jwt.decode(req.headers.token).data._id; // eslint-disable-line
+  GameLog.find({ playerId: mongoose.Types.ObjectId(playerId) }).select('-_id').exec((err, gameLogs) => {
+    if (err) {
+      res.render('error', {
+        status: 500
+      });
+    } else {
+      res.send(gameLogs);
     }
-    return res.status(200).send({ message: 'Game saved' });
+  });
+};
+
+export const retrieveLeaderBoard = (req, res) => {
+  User.find(
+    { gamesWon: { $gt: 1 } },
+    { name: 1, gamesWon: 1 }
+  ).sort({ gamesWon: -1 }).select('-_id').exec((err, leaderBoard) => {
+    if (err) {
+      res.render('error', {
+        status: 500
+      });
+    } else {
+      res.send(leaderBoard);
+    }
+  });
+};
+
+export const retrieveDonations = (req, res) => {
+  const playerId = jwt.decode(req.headers.token).data._id; // eslint-disable-line
+  User.find({ _id: mongoose.Types.ObjectId(playerId) }).select('-_id').exec((err, user) => {
+    if (err) {
+      res.render('error', {
+        status: 500
+      });
+    } else {
+      res.send(user[0].donations);
+    }
   });
 };

--- a/src/app/models/gameLog.js
+++ b/src/app/models/gameLog.js
@@ -7,9 +7,8 @@ import mongoose, { Schema } from 'mongoose';
  * Games Schema
  */
 const GameLog = new Schema({
-  id: {
-    type: Number,
-
+  playerId: {
+    type: String,
   },
   players: {
     type: Array,

--- a/src/app/models/user.js
+++ b/src/app/models/user.js
@@ -18,6 +18,7 @@ const UserSchema = new Schema({
   avatar: String,
   premium: Number, // null or 0 for non-donors, 1 for everyone else (for now)
   donations: [],
+  gamesWon: { type: Number, default: 0 },
   hashed_password: String,
   facebook: {},
   twitter: {},

--- a/src/app/views/includes/foot.jade
+++ b/src/app/views/includes/foot.jade
@@ -34,12 +34,18 @@ script(type='text/javascript', src='/js/services/token.js')
 script(type='text/javascript', src='/js/services/auth.js')
 script(type='text/javascript', src='/js/services/userSearch.js')
 script(type='text/javascript', src='/js/services/injector.js')
+script(type='text/javascript', src='/js/services/dashboard.js')
 
 //Application Controllers
 script(type='text/javascript', src='/js/controllers/index.js')
 script(type='text/javascript', src='/js/controllers/header.js')
 script(type='text/javascript', src='/js/controllers/game.js')
+
+script(type='text/javascript', src='/js/components/leaderBoard.js')
+script(type='text/javascript', src='/js/components/gameLog.js')
+script(type='text/javascript', src='/js/components/donations.js')
 script(type='text/javascript', src='/js/init.js')
+
 
 //Socket.io Client Library
 script(type='text/javascript', src='/socket.io/socket.io.js')

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -8,7 +8,7 @@ import { all as allAnswers, show as showAnswers, answer as getAnswer } from '../
 import { all as allQuestions, show as showQuestion, question as getQuestion } from '../app/controllers/questions';
 import { allJSON } from '../app/controllers/avatars';
 import { play, render } from '../app/controllers/index';
-import { startGame } from '../app/controllers/gameLog';
+import { startGame, retrieveGameLog, retrieveLeaderBoard, retrieveDonations } from '../app/controllers/gameLog';
 import fieldValidationMiddleware from './middlewares/fieldValidationMiddleware';
 import authMiddleware from './middlewares/authentication';
 
@@ -127,5 +127,8 @@ export default function(app, passport, auth) {  // eslint-disable-line
     },
     jwtLogin);
 
-  app.post('/api/games/:id/start', startGame);
+  app.post('/api/games/:id/start', authMiddleware, startGame);
+  app.get('/api/games/history', authMiddleware, retrieveGameLog);
+  app.get('/api/leaderboard', authMiddleware, retrieveLeaderBoard);
+  app.get('/api/donations', authMiddleware, retrieveDonations);
 }

--- a/src/config/socket/game.js
+++ b/src/config/socket/game.js
@@ -68,7 +68,8 @@ Game.prototype.payload = function () {
       avatar: player.avatar,
       premium: player.premium,
       socketID: player.socket.id,
-      color: player.color
+      color: player.color,
+      userId: player.userID
     });
   });
   return {


### PR DESCRIPTION
What does this PR do?
* Fix gamelog to store game sessions for every authenticated user in a game
* Implement Games, Leader Board and Donations tabs on the dashboard

Description of Task to be completed
* A registered user should be able to view a "game log" of previously played games. The game log should reference the friends played with, number of rounds and overall winner of the different games played

How should this be manually tested?
* Sign in to the app and play the game with other registered friends or guests.
* Follow the `Dashboard` link on the nav bar to see the following:
    * Summary of every game session (Games)
    * Players and the number of games won (Leader Board)
    * Summary of the donations you have made (Donations)

What are the relevant pivotal tracker stories?
* Registered users should be able to view a a "game log" of past games: #150438337

<img width="1280" alt="screen shot 2017-09-19 at 11 09 01 pm" src="https://user-images.githubusercontent.com/15054956/30617787-94c74020-9d8f-11e7-9edd-06abc96465e6.png">
